### PR TITLE
Less strict version check in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     use_setuptools()
     from setuptools import setup
 
-if sys.version_info < (2, 7, 3) or sys.version_info >= (2, 7, 7):
+if sys.version_info < (2, 7, 3) or sys.version_info >= (3, 0, 0):
     raise Exception('ChEMBL software stack requires python 2.7.3 - 2.7.7')
 
 setup(


### PR DESCRIPTION
The check `sys.version_info >= (2, 7, 7)` evaluates to True on Python 2.7.7, causing an exception to be raised when trying to install. This change increases the limit to `(3, 0, 0)`, so installation is allowed on all future 2.7.x Python versions, but not Python 3+.

Alternatively, if you want to be more strict, you could use `(2, 7, 8)`, but I don't think any future 2.7.x versions will cause any issues.
